### PR TITLE
Expose public API and add coverage for model workflows

### DIFF
--- a/src/latentflow/__init__.py
+++ b/src/latentflow/__init__.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+"""
+LatentFlow public API.
+
+This package exposes the main estimators, sampling helpers, and configuration
+loader so downstream projects can import them directly from ``latentflow``.
+"""
+
+from latentflow.config import load_experiment_config
+from latentflow.models.hmm import GaussianARHMM, GaussianHMM, GMMARHMM, GMMHMM
+from latentflow.sampler import (
+    make_random_gaussian_arhmm,
+    make_random_gaussian_hmm,
+    make_random_gaussian_mixture_arhmm,
+    make_random_gaussian_mixture_hmm,
+    sample_any_hmm,
+    sample_gaussian_arhmm,
+    sample_gaussian_hmm,
+    sample_gmm_arhmm,
+    sample_gmm_hmm,
+)
+
+__all__ = [
+    "GaussianHMM",
+    "GaussianARHMM",
+    "GMMHMM",
+    "GMMARHMM",
+    "sample_gaussian_hmm",
+    "sample_gaussian_arhmm",
+    "sample_gmm_hmm",
+    "sample_gmm_arhmm",
+    "sample_any_hmm",
+    "make_random_gaussian_hmm",
+    "make_random_gaussian_arhmm",
+    "make_random_gaussian_mixture_hmm",
+    "make_random_gaussian_mixture_arhmm",
+    "load_experiment_config",
+]

--- a/src/latentflow/cli.py
+++ b/src/latentflow/cli.py
@@ -1,8 +1,8 @@
-"""Command-line interface for the hmm package."""
+"""Command-line interface for the latentflow package."""
 
-from hmm.sampler import make_random_gaussian_hmm, sample_gaussian_hmm
-from hmm.models.hmm import GaussianHMM
-from hmm.visualize import plot_hmm_series_with_states
+from latentflow.models.hmm import GaussianHMM
+from latentflow.sampler import make_random_gaussian_hmm, sample_gaussian_hmm
+from latentflow.visualize import plot_hmm_series_with_states
 
 
 def main():
@@ -78,4 +78,3 @@ def sampler_main():
 
 if __name__ == "__main__":
     main()
-

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import numpy as np
+
+from latentflow import (
+    GaussianARHMM,
+    GaussianHMM,
+    GMMARHMM,
+    GMMHMM,
+    make_random_gaussian_arhmm,
+    make_random_gaussian_hmm,
+    make_random_gaussian_mixture_arhmm,
+    make_random_gaussian_mixture_hmm,
+    sample_gaussian_arhmm,
+    sample_gaussian_hmm,
+    sample_gmm_arhmm,
+    sample_gmm_hmm,
+)
+
+
+def _assert_probabilities(proba: np.ndarray) -> None:
+    np.testing.assert_allclose(proba.sum(axis=1), 1.0, atol=1e-6)
+    assert np.all(proba >= 0.0)
+
+
+def test_gaussian_hmm_fit_predict_roundtrip():
+    rng = np.random.default_rng(0)
+    params = make_random_gaussian_hmm(n_states=3, n_features=2, rng=rng)
+    true_states, obs = sample_gaussian_hmm(params, T=60, rng=rng)
+
+    model = GaussianHMM(
+        n_components=3,
+        covariance_type="full",
+        n_iter=15,
+        tol=1e-3,
+        reg_covar=1e-5,
+        init="random",
+        random_state=0,
+    )
+    model.fit(obs)
+
+    preds = model.predict(obs)
+    assert preds.shape == true_states.shape
+
+    proba = model.predict_proba(obs)
+    assert proba.shape == (len(obs), 3)
+    _assert_probabilities(proba)
+
+    score = model.score(obs)
+    assert np.isfinite(score)
+
+
+def test_gaussian_arhmm_handles_autoregressive_design():
+    rng = np.random.default_rng(1)
+    params = make_random_gaussian_arhmm(n_states=2, n_features=2, order=1, rng=rng)
+    _, obs = sample_gaussian_arhmm(params, T=70, rng=rng)
+
+    model = GaussianARHMM(
+        n_components=2,
+        order=1,
+        covariance_type="full",
+        n_iter=12,
+        tol=1e-3,
+        init="random",
+        random_state=1,
+    )
+    model.fit(obs)
+
+    proba = model.predict_proba(obs)
+    assert proba.shape == (len(obs), 2)
+    _assert_probabilities(proba)
+
+    sampled_states, sampled_obs = model.sample(T=10)
+    assert sampled_states.shape == (10,)
+    assert sampled_obs.shape[0] == 10
+
+
+def test_gmm_hmm_supports_mixture_emissions():
+    rng = np.random.default_rng(2)
+    params = make_random_gaussian_mixture_hmm(
+        n_states=2,
+        n_features=2,
+        n_mixtures=2,
+        covariance_type="diag",
+        rng=rng,
+    )
+    _, obs = sample_gmm_hmm(params, T=50, rng=rng)
+
+    model = GMMHMM(
+        n_components=2,
+        n_mixtures=2,
+        covariance_type="diag",
+        n_iter=12,
+        tol=1e-3,
+        init="random",
+        random_state=2,
+    )
+    model.fit(obs)
+
+    preds = model.predict(obs)
+    assert preds.shape == (len(obs),)
+
+    proba = model.predict_proba(obs)
+    assert proba.shape == (len(obs), 2)
+    _assert_probabilities(proba)
+
+
+def test_gmm_arhmm_runs_end_to_end():
+    rng = np.random.default_rng(3)
+    params = make_random_gaussian_mixture_arhmm(
+        n_states=2,
+        n_features=2,
+        order=1,
+        n_mixtures=2,
+        covariance_type="diag",
+        rng=rng,
+    )
+    _, obs = sample_gmm_arhmm(params, T=45, rng=rng)
+
+    model = GMMARHMM(
+        n_components=2,
+        n_mixtures=2,
+        order=1,
+        covariance_type="diag",
+        n_iter=10,
+        tol=1e-3,
+        init="random",
+        random_state=3,
+    )
+    model.fit(obs)
+
+    proba = model.predict_proba(obs)
+    assert proba.shape == (len(obs), 2)
+    _assert_probabilities(proba)
+

--- a/tests/test_utils_and_sampling.py
+++ b/tests/test_utils_and_sampling.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import numpy as np
+
+from latentflow.sampler import (
+    make_random_gaussian_hmm,
+    sample_any_hmm,
+    sample_gaussian_hmm,
+)
+from latentflow.utils import _check_random_state
+
+
+def test_check_random_state_accepts_int_and_generator():
+    rng_from_int = _check_random_state(42)
+    assert isinstance(rng_from_int, np.random.Generator)
+    value_int = rng_from_int.random()
+
+    base_rng = np.random.default_rng(42)
+    rng_from_rng = _check_random_state(base_rng)
+    value_rng = rng_from_rng.random()
+
+    assert np.isfinite(value_int)
+    assert np.isfinite(value_rng)
+
+
+def test_sample_any_hmm_dispatches_gaussian_hmm():
+    rng = np.random.default_rng(5)
+    params = make_random_gaussian_hmm(n_states=2, n_features=2, rng=rng)
+    states, obs = sample_any_hmm(params, T=5, rng=rng)
+
+    assert states.shape == (5,)
+    assert obs.shape == (5, params.n_features)
+
+    states_direct, obs_direct = sample_gaussian_hmm(params, T=5, rng=rng)
+    assert states_direct.shape == states.shape
+    assert obs_direct.shape == obs.shape


### PR DESCRIPTION
## Summary
- expose the main estimators, samplers, and config loader through the package root for easier reuse
- fix the CLI imports to point at the latentflow package instead of the old module path
- add end-to-end unit tests covering Gaussian, AR, and mixture HMM variants plus sampling helpers

## Testing
- pytest *(fails: environment cannot install numpy dependency due to offline package index)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945c5e97c44832e941280a7b518f4b5)