### PR TITLE
Add result analysis and interactive reporting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "matplotlib>=3.10.7",
     "numpy>=2.3.4",
     "pandas>=2.3.3",
+    "plotly>=5.24.1",
     "scikit-learn>=1.7.2",
     "scipy>=1.16.3",
     "seaborn>=0.13.2",

--- a/scripts/run_hmm_experiment.py
+++ b/scripts/run_hmm_experiment.py
@@ -1,5 +1,7 @@
 import argparse
 import sys
+import webbrowser
+from dataclasses import fields, is_dataclass
 from pathlib import Path
 
 # Add src directory to path for editable installs
@@ -11,9 +13,11 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 from latentflow.config import load_experiment_config
+from latentflow.analysis import ResultAnalyzer
 from latentflow.sampler import sample_any_hmm
 from latentflow.models.hmm import GaussianHMM, GaussianARHMM, GMMHMM, GMMARHMM
 from latentflow.params import GaussianHMMParams, GaussianARHMMParams, GMMHMMParams, GMMARHMMParams
+from latentflow.reporting import HTMLReport, make_timeseries_section
 from latentflow.visualize import plot_hmm_series_with_states
 
 
@@ -28,6 +32,25 @@ def get_model_class(params):
         return GMMARHMM
     else:
         raise TypeError(f"Unsupported parameter type: {type(params)}")
+
+
+def _flatten_params_for_metrics(param_obj) -> dict[str, float]:
+    """
+    Flatten a parameter dataclass into a mapping of label -> value.
+
+    This preserves field ordering and uses C-order flattening for arrays so that
+    true and estimated parameters align for metric computation.
+    """
+    if not is_dataclass(param_obj):
+        raise TypeError("Parameter object must be a dataclass.")
+
+    flat: dict[str, float] = {}
+    for field in fields(param_obj):
+        value = getattr(param_obj, field.name)
+        arr = np.asarray(value, dtype=float).ravel()
+        for idx, val in enumerate(arr):
+            flat[f"{field.name}[{idx}]"] = float(val)
+    return flat
 
 
 if __name__ == "__main__":
@@ -118,3 +141,57 @@ if __name__ == "__main__":
         # Only show if explicit request or no output file?
         # Standard behavior: show() if interactive or no file specified.
         plt.show()
+
+    # ------------------------------------------------------------------
+    # Interactive HTML report with metrics
+    # ------------------------------------------------------------------
+    analyzer = ResultAnalyzer()
+    metrics_table = {}
+
+    if model.params is not None:
+        try:
+            true_flat = _flatten_params_for_metrics(params)
+            est_flat = _flatten_params_for_metrics(model.params)
+            metrics_table = analyzer.evaluate_parameters(true_flat, est_flat)
+        except Exception as exc:  # pragma: no cover - diagnostics only
+            print(f"Warning: could not compute parameter metrics: {exc}")
+
+    # Include simple prediction accuracy over hidden states
+    metrics_table["state_accuracy"] = float(np.mean(pred_states == true_states))
+    if model.loglik is not None:
+        metrics_table["log_likelihood"] = float(model.loglik)
+
+    report = HTMLReport(title=f"{model_name_display} Experiment Results")
+    cov_names = [f"cov{i+1}" for i in range(params.n_features)]
+
+    report.add_section(
+        make_timeseries_section(
+            title=f"True {model_name_display} Process",
+            x=list(range(T)),
+            Y=obs,
+            states=true_states,
+            covariate_names=cov_names,
+            description="Observed covariates with true hidden-state shading.",
+        )
+    )
+    report.add_section(
+        make_timeseries_section(
+            title=f"Predicted {model_name_display} Process",
+            x=list(range(T)),
+            Y=obs,
+            states=pred_states,
+            covariate_names=cov_names,
+            description="Observed covariates with predicted hidden-state shading.",
+        )
+    )
+
+    if metrics_table:
+        report.add_table(metrics_table, title="Parameter & Prediction Metrics")
+
+    html_output = Path(run_config.get("html_output", Path(args.config).with_suffix(".html")))
+    saved_path = report.save(html_output)
+    print(f"Saved interactive report to {saved_path}")
+    try:
+        webbrowser.open(saved_path.resolve().as_uri())
+    except Exception as exc:  # pragma: no cover - best-effort open
+        print(f"Warning: could not open report automatically: {exc}")

--- a/src/latentflow/__init__.py
+++ b/src/latentflow/__init__.py
@@ -9,6 +9,8 @@ loader so downstream projects can import them directly from ``latentflow``.
 
 from latentflow.config import load_experiment_config
 from latentflow.models.hmm import GaussianARHMM, GaussianHMM, GMMARHMM, GMMHMM
+from latentflow.analysis import ResultAnalyzer, ResultRecord, ResultStore, MetricRegistry
+from latentflow.reporting import HTMLReport, ReportSection, build_timeseries_report, make_timeseries_section
 from latentflow.sampler import (
     make_random_gaussian_arhmm,
     make_random_gaussian_hmm,
@@ -26,6 +28,14 @@ __all__ = [
     "GaussianARHMM",
     "GMMHMM",
     "GMMARHMM",
+    "ResultAnalyzer",
+    "ResultRecord",
+    "ResultStore",
+    "MetricRegistry",
+    "HTMLReport",
+    "ReportSection",
+    "build_timeseries_report",
+    "make_timeseries_section",
     "sample_gaussian_hmm",
     "sample_gaussian_arhmm",
     "sample_gmm_hmm",

--- a/src/latentflow/analysis.py
+++ b/src/latentflow/analysis.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+"""
+Result analysis utilities for LatentFlow.
+
+This module makes it easy to persist evaluation results from tests or
+experiments and compute summary statistics over estimated parameters. It ships
+with a handful of common metrics (RMSE, MAE, MAPE) and exposes a registry so
+callers can register additional metrics without having to change the core
+package. Results are stored as JSON on disk to keep them portable and easy to
+inspect.
+"""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence
+
+import json
+
+import numpy as np
+
+MetricFunc = Callable[[np.ndarray, np.ndarray], float]
+
+
+def _as_array(values: Sequence[float] | Mapping[str, float], *, expected_keys: Optional[List[str]] = None) -> tuple[np.ndarray, Optional[List[str]]]:
+    """Convert parameter containers into an array while preserving ordering.
+
+    If a mapping is provided, keys are sorted alphabetically to ensure a stable
+    ordering. When ``expected_keys`` is provided we will reorder to match the
+    expected keys and raise if any key is missing.
+    """
+
+    if isinstance(values, Mapping):
+        if expected_keys is None:
+            keys = sorted(values)
+        else:
+            missing = set(expected_keys) - set(values)
+            if missing:
+                missing_list = ", ".join(sorted(missing))
+                raise ValueError(f"Estimated values are missing keys: {missing_list}")
+            keys = list(expected_keys)
+        arr = np.asarray([values[k] for k in keys], dtype=float)
+        return arr, keys
+
+    arr = np.asarray(values, dtype=float)
+    return arr, None
+
+
+def _rmse(y_true: np.ndarray, y_pred: np.ndarray) -> float:
+    return float(np.sqrt(np.mean(np.square(y_pred - y_true))))
+
+
+def _mae(y_true: np.ndarray, y_pred: np.ndarray) -> float:
+    return float(np.mean(np.abs(y_pred - y_true)))
+
+
+def _mape(y_true: np.ndarray, y_pred: np.ndarray) -> float:
+    denom = np.where(y_true == 0, np.nan, y_true)
+    return float(np.nanmean(np.abs((y_pred - y_true) / denom)) * 100.0)
+
+
+class MetricRegistry:
+    """Registry of metric functions.
+
+    The registry ships with a few defaults and allows users to register their
+    own metrics. Each metric function should accept two numpy arrays (true
+    values, predicted values) and return a float.
+    """
+
+    def __init__(self) -> None:
+        self._metrics: MutableMapping[str, MetricFunc] = {
+            "rmse": _rmse,
+            "mae": _mae,
+            "mape": _mape,
+        }
+
+    def register(self, name: str, func: MetricFunc, *, overwrite: bool = False) -> None:
+        if not overwrite and name in self._metrics:
+            raise ValueError(f"Metric '{name}' is already registered. Use overwrite=True to replace it.")
+        self._metrics[name] = func
+
+    def compute(self, name: str, y_true: np.ndarray, y_pred: np.ndarray) -> float:
+        if name not in self._metrics:
+            raise KeyError(f"Metric '{name}' is not registered.")
+        return self._metrics[name](y_true, y_pred)
+
+    def compute_many(self, names: Iterable[str], y_true: np.ndarray, y_pred: np.ndarray) -> Dict[str, float]:
+        return {name: self.compute(name, y_true, y_pred) for name in names}
+
+    @property
+    def metric_names(self) -> List[str]:
+        return list(self._metrics)
+
+
+class ResultAnalyzer:
+    """Compute metrics over estimated parameters.
+
+    Examples
+    --------
+    >>> analyzer = ResultAnalyzer()
+    >>> metrics = analyzer.evaluate_parameters([1.0, 2.0], [1.1, 1.9])
+    >>> sorted(metrics)
+    ['mae', 'mape', 'rmse']
+    """
+
+    def __init__(self, registry: Optional[MetricRegistry] = None) -> None:
+        self.registry = registry or MetricRegistry()
+
+    def evaluate_parameters(
+        self,
+        true_params: Sequence[float] | Mapping[str, float],
+        estimated_params: Sequence[float] | Mapping[str, float],
+        *,
+        metrics: Optional[Iterable[str]] = None,
+    ) -> Dict[str, float]:
+        y_true, keys = _as_array(true_params)
+        y_pred, _ = _as_array(estimated_params, expected_keys=keys)
+
+        if y_true.shape != y_pred.shape:
+            raise ValueError("true_params and estimated_params must have the same shape after alignment.")
+
+        metric_names = list(metrics) if metrics is not None else self.registry.metric_names
+        return self.registry.compute_many(metric_names, y_true, y_pred)
+
+    def register_metric(self, name: str, func: MetricFunc, *, overwrite: bool = False) -> None:
+        """Convenience wrapper around ``MetricRegistry.register``."""
+
+        self.registry.register(name, func, overwrite=overwrite)
+
+
+@dataclass
+class ResultRecord:
+    test_name: str
+    true_params: Sequence[float] | Mapping[str, float]
+    estimated_params: Sequence[float] | Mapping[str, float]
+    metrics: Mapping[str, float]
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        def _make_serializable(obj: Any) -> Any:
+            if isinstance(obj, np.ndarray):
+                return obj.tolist()
+            if isinstance(obj, (list, tuple)):
+                return list(obj)
+            if isinstance(obj, Mapping):
+                return {k: _make_serializable(v) for k, v in obj.items()}
+            return obj
+
+        return {
+            "test_name": self.test_name,
+            "true_params": _make_serializable(self.true_params),
+            "estimated_params": _make_serializable(self.estimated_params),
+            "metrics": _make_serializable(self.metrics),
+            "metadata": _make_serializable(self.metadata),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "ResultRecord":
+        return cls(
+            test_name=payload["test_name"],
+            true_params=payload["true_params"],
+            estimated_params=payload["estimated_params"],
+            metrics=payload.get("metrics", {}),
+            metadata=payload.get("metadata", {}),
+        )
+
+
+class ResultStore:
+    """Persist and reload ``ResultRecord`` objects.
+
+    Each store writes to a single JSON file containing a list of result
+    dictionaries. The file is created if it does not exist yet.
+    """
+
+    def __init__(self, path: str | Path) -> None:
+        self.path = Path(path)
+
+    def append(self, record: ResultRecord) -> None:
+        records = self._load_json()
+        records.append(record.to_dict())
+        self._write_json(records)
+
+    def load(self) -> List[ResultRecord]:
+        return [ResultRecord.from_dict(entry) for entry in self._load_json()]
+
+    def clear(self) -> None:
+        if self.path.exists():
+            self.path.unlink()
+
+    def _load_json(self) -> List[Dict[str, Any]]:
+        if not self.path.exists():
+            return []
+        text = self.path.read_text()
+        if not text.strip():
+            return []
+        try:
+            payload = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Could not parse result store at {self.path}") from exc
+        if not isinstance(payload, list):
+            raise ValueError("Result store must contain a list of result dictionaries.")
+        return payload
+
+    def _write_json(self, payload: List[Dict[str, Any]]) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.write_text(json.dumps(payload, indent=2))
+

--- a/src/latentflow/reporting.py
+++ b/src/latentflow/reporting.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+"""
+HTML reporting utilities for LatentFlow visualizations and statistics.
+
+This module builds interactive plots and summary tables in a single HTML file
+so results can be shared or inspected later. It is intentionally lightweight
+and pure-Python to avoid adding heavyweight notebook dependencies.
+"""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence
+
+import json
+
+import numpy as np
+import pandas as pd
+import plotly.graph_objects as go
+
+from .visualize import _as_numpy_1d, _as_numpy_2d, _get_index_like
+
+
+def _default_table(data: Mapping[str, Any]) -> go.Figure:
+    headers = list(data)
+    values = [[data[h]] if not isinstance(data[h], list) else data[h] for h in headers]
+    return go.Figure(
+        data=[
+            go.Table(
+                header=dict(values=headers, fill_color="#0f172a", font=dict(color="white"), align="left"),
+                cells=dict(values=values, fill_color="#e2e8f0", align="left"),
+            )
+        ]
+    )
+
+
+def _timeseries_figure(
+    x: Sequence[Any],
+    Y: Sequence[Sequence[float]],
+    series_names: Sequence[str],
+    *,
+    title: str | None = None,
+    state_spans: Optional[List[Dict[str, Any]]] = None,
+) -> go.Figure:
+    fig = go.Figure()
+    for col, name in zip(np.asarray(Y).T, series_names):
+        fig.add_trace(go.Scatter(x=x, y=col, mode="lines", name=name))
+
+    if state_spans:
+        for span in state_spans:
+            fig.add_vrect(**span)
+
+    fig.update_layout(title=title, template="plotly_white", hovermode="x unified")
+    fig.update_xaxes(title_text="Time")
+    fig.update_yaxes(title_text="Value")
+    return fig
+
+
+def _compute_state_spans(x_values: Sequence[Any], states: Sequence[int], palette: Mapping[int, str]) -> List[Dict[str, Any]]:
+    segments: List[Dict[str, Any]] = []
+    if len(x_values) == 0:
+        return segments
+    start = 0
+    current_state = states[0]
+    for i in range(1, len(states)):
+        if states[i] != current_state:
+            segments.append(
+                dict(
+                    x0=x_values[start],
+                    x1=x_values[i],
+                    fillcolor=palette[current_state],
+                    opacity=0.16,
+                    line_width=0,
+                    annotation_text=f"State {current_state}",
+                )
+            )
+            start = i
+            current_state = states[i]
+    segments.append(
+        dict(
+            x0=x_values[start],
+            x1=x_values[-1],
+            fillcolor=palette[current_state],
+            opacity=0.16,
+            line_width=0,
+            annotation_text=f"State {current_state}",
+        )
+    )
+    return segments
+
+
+def _infer_palette(states: Sequence[int]) -> Dict[int, str]:
+    cmap = go.Figure().to_dict()["layout"].get("colorway", []) or [
+        "#1f77b4",
+        "#ff7f0e",
+        "#2ca02c",
+        "#d62728",
+        "#9467bd",
+    ]
+    unique_states = sorted(set(states))
+    return {s: cmap[i % len(cmap)] for i, s in enumerate(unique_states)}
+
+
+@dataclass
+class ReportSection:
+    title: str
+    figure: go.Figure
+    description: Optional[str] = None
+
+    def to_html(self) -> str:
+        html = self.figure.to_html(include_plotlyjs=False, full_html=False)
+        desc_block = f"<p>{self.description}</p>" if self.description else ""
+        return f"<section><h2>{self.title}</h2>{desc_block}{html}</section>"
+
+
+@dataclass
+class HTMLReport:
+    title: str
+    sections: List[ReportSection] = field(default_factory=list)
+    tables: List[Mapping[str, Any]] = field(default_factory=list)
+    additional_html: List[str] = field(default_factory=list)
+
+    def add_section(self, section: ReportSection) -> None:
+        self.sections.append(section)
+
+    def add_table(self, table: Mapping[str, Any], *, title: str | None = None) -> None:
+        fig = _default_table(table)
+        self.sections.append(ReportSection(title=title or "Summary", figure=fig))
+
+    def to_html(self) -> str:
+        body = []
+        for section in self.sections:
+            body.append(section.to_html())
+        body.extend(self.additional_html)
+        return "\n".join(
+            [
+                "<html>",
+                "<head>",
+                f"<title>{self.title}</title>",
+                '<script src="https://cdn.plot.ly/plotly-2.32.0.min.js"></script>',
+                '<style>body{font-family:Inter,system-ui,sans-serif;margin:24px;} h1,h2{color:#0f172a;} section{margin-bottom:36px;} table{border-collapse:collapse;}</style>',
+                "</head>",
+                "<body>",
+                f"<h1>{self.title}</h1>",
+                "\n".join(body),
+                "</body>",
+                "</html>",
+            ]
+        )
+
+    def save(self, path: str | Path) -> Path:
+        path = Path(path)
+        path.write_text(self.to_html())
+        return path
+
+
+def build_timeseries_report(
+    *,
+    x: Sequence[Any],
+    Y: Sequence[Sequence[float]] | np.ndarray | pd.DataFrame,
+    states: Sequence[int],
+    covariate_names: Optional[Sequence[str]] = None,
+    metrics_table: Optional[Mapping[str, Any]] = None,
+    title: str = "LatentFlow Results",
+    description: Optional[str] = None,
+    include_state_annotations: bool = True,
+) -> HTMLReport:
+    x_values = _get_index_like(x)
+    y_values = _as_numpy_2d(Y)
+    if y_values.shape[0] != len(x_values):
+        raise ValueError("Length of x must match rows in Y.")
+
+    if hasattr(Y, "columns"):
+        names = list(map(str, Y.columns))
+    elif covariate_names is not None:
+        names = list(map(str, covariate_names))
+    else:
+        names = [f"y{i}" for i in range(y_values.shape[1])]
+
+    palette = _infer_palette(states)
+    spans = _compute_state_spans(x_values, states, palette) if include_state_annotations else None
+
+    fig = _timeseries_figure(x_values, y_values, names, title="Time series with hidden states", state_spans=spans)
+    section_desc = description or "Interactive view of observed series with hidden-state shading."
+    report = HTMLReport(title=title, sections=[ReportSection(title="Time series", figure=fig, description=section_desc)])
+
+    if metrics_table:
+        report.add_table(metrics_table, title="Metrics")
+
+    return report
+
+
+def make_timeseries_section(
+    *,
+    title: str,
+    x: Sequence[Any],
+    Y: Sequence[Sequence[float]] | np.ndarray | pd.DataFrame,
+    states: Sequence[int],
+    covariate_names: Optional[Sequence[str]] = None,
+    description: Optional[str] = None,
+    include_state_annotations: bool = True,
+) -> ReportSection:
+    """
+    Convenience helper to build a ``ReportSection`` with a Plotly time-series figure
+    and optional hidden-state shading.
+    """
+    x_values = _get_index_like(x)
+    y_values = _as_numpy_2d(Y)
+    if y_values.shape[0] != len(x_values):
+        raise ValueError("Length of x must match rows in Y.")
+
+    if hasattr(Y, "columns"):
+        names = list(map(str, Y.columns))
+    elif covariate_names is not None:
+        names = list(map(str, covariate_names))
+    else:
+        names = [f"y{i}" for i in range(y_values.shape[1])]
+
+    palette = _infer_palette(states)
+    spans = _compute_state_spans(x_values, states, palette) if include_state_annotations else None
+    fig = _timeseries_figure(x_values, y_values, names, title=title, state_spans=spans)
+    section_desc = description or "Interactive time-series view."
+    return ReportSection(title=title, figure=fig, description=section_desc)

--- a/src/latentflow/visualize.py
+++ b/src/latentflow/visualize.py
@@ -6,6 +6,7 @@ import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
 
+from latentflow.reporting import build_timeseries_report
 
 ArrayLike1D = Union[Sequence[float], np.ndarray]
 ArrayLike2D = Union[Sequence[Sequence[float]], np.ndarray]
@@ -337,6 +338,64 @@ def plot_faceted_hmm_series_with_states(
         fig.suptitle(title)
     fig.tight_layout()
     return fig, axes
+
+
+def build_interactive_html(
+    *,
+    x: Union[ArrayLike1D, pd.Index, pd.Series],
+    Y: Union[ArrayLike2D, pd.DataFrame, pd.Series],
+    states: Sequence[int],
+    covariate_names: Optional[Sequence[str]] = None,
+    metrics_table: Optional[Mapping[str, Union[float, str, Sequence[Union[float, str]]]]] = None,
+    title: str = "LatentFlow Results",
+    description: Optional[str] = None,
+    include_state_annotations: bool = True,
+    output_path: Optional[str] = None,
+) -> str:
+    """
+    Build an interactive HTML report that combines time-series plots, hidden state
+    shading, and optional metric tables.
+
+    Parameters
+    ----------
+    x : array-like or pandas Index/Series
+        X-axis values (e.g., timestamps).
+    Y : array-like 2D or pandas DataFrame/Series
+        Observed covariates.
+    states : Sequence[int]
+        Hidden state assignments for each time step.
+    covariate_names : Sequence[str], optional
+        Names for each covariate if Y is not a DataFrame.
+    metrics_table : Mapping[str, Any], optional
+        A mapping of metric name -> value (or list of values) to render as a table.
+    title : str
+        Title of the HTML report.
+    description : str, optional
+        Text description included above the time-series chart.
+    include_state_annotations : bool
+        Whether to shade state segments in the interactive plot.
+    output_path : str, optional
+        If provided, save the HTML to this path and return it. Otherwise, return
+        the HTML string.
+
+    Returns
+    -------
+    str
+        Path to the saved HTML (if output_path provided) or the HTML content.
+    """
+    report = build_timeseries_report(
+        x=x,
+        Y=Y,
+        states=states,
+        covariate_names=covariate_names,
+        metrics_table=metrics_table,
+        title=title,
+        description=description,
+        include_state_annotations=include_state_annotations,
+    )
+    if output_path:
+        return str(report.save(output_path))
+    return report.to_html()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- add a reusable result analysis module with extensible metric registry and JSON-backed result storage
- introduce interactive HTML reporting utilities for time-series plots and metrics tables, with a reusable section builder exported via the package API
- update the experiment runner to compute parameter and state metrics, emit an interactive HTML report automatically, and open it after each run
- add Plotly dependency to support interactive visualizations

## Testing
- PYTHONPATH=src pytest -q --disable-warnings --maxfail=1 *(not run: dependency installation blocked by proxy, NumPy unavailable)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945c9ddd11c832eabbe33482260c023)